### PR TITLE
Fix for really annoying bug

### DIFF
--- a/bankfacil:vanilla-masker/package.js
+++ b/bankfacil:vanilla-masker/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   summary: "VanillaMasker is a pure javascript input mask.",
-  version: "1.0.9",
+  version: "1.1.0",
   git: "https://github.com/BankFacil/vanilla-masker"
 });
 

--- a/lib/vanilla-masker.js
+++ b/lib/vanilla-masker.js
@@ -90,18 +90,17 @@
   VanillaMasker.prototype.maskMoney = function(opts) {
     this.opts = mergeMoneyOptions(opts);
 
-    // Suppose this mask recieve a value "9"
-    // How this mask expects a value with floating numbers
-    // the "9" will be pushed after the separator
-    // and will become "0,09". So we just add ".00".
-    var value;
+    // Ensures the number are in format \d+.{precision}
+    var value,
+        precision = opts.precision || 2;
     for (var i = 0, len = this.elements.length; i < len; i++) {
-      value = this.elements[i].value;
-      if (value.length) {
-        this.elements[i].value = (/\./g).test(value) ? value : value + '.00';
+      value = parseFloat(this.elements[i].value);
+      if (!isNaN(parseFloat(value))) {
+        this.elements[i].value = value.toFixed(precision);
       }
     }
     value = null;
+    precision = null;
 
     this.bindElementToMask("toMoney");
   };

--- a/lib/vanilla-masker.js
+++ b/lib/vanilla-masker.js
@@ -92,7 +92,7 @@
 
     // Ensures the number are in format \d+.{precision}
     var value,
-        precision = opts.precision || 2;
+        precision = this.opts.precision;
     for (var i = 0, len = this.elements.length; i < len; i++) {
       value = parseFloat(this.elements[i].value);
       if (!isNaN(parseFloat(value))) {

--- a/lib/vanilla-masker.js
+++ b/lib/vanilla-masker.js
@@ -132,6 +132,12 @@
       if (digitsLength < lastDigitLength) {
         value = value.slice(0, value.length - 1);
       }
+    } else {
+      // Suppose this fn recieve a value "9"
+      // How this mask expects a value with floating numbers
+      // the "9" will be pushed after the separator
+      // and will become "0,09". So we just add ".00".
+      value = (/\./g).test(value) ? value : value + '.00';
     }
     var number = value.toString().replace(/[\D]/g, ""),
         clearDelimiter = new RegExp("^(0|\\"+ opts.delimiter +")"),

--- a/lib/vanilla-masker.js
+++ b/lib/vanilla-masker.js
@@ -89,6 +89,20 @@
 
   VanillaMasker.prototype.maskMoney = function(opts) {
     this.opts = mergeMoneyOptions(opts);
+
+    // Suppose this mask recieve a value "9"
+    // How this mask expects a value with floating numbers
+    // the "9" will be pushed after the separator
+    // and will become "0,09". So we just add ".00".
+    var value;
+    for (var i = 0, len = this.elements.length; i < len; i++) {
+      value = this.elements[i].value;
+      if (value.length) {
+        this.elements[i].value = (/\./g).test(value) ? value : value + '.00';
+      }
+    }
+    value = null;
+
     this.bindElementToMask("toMoney");
   };
 
@@ -132,12 +146,6 @@
       if (digitsLength < lastDigitLength) {
         value = value.slice(0, value.length - 1);
       }
-    } else {
-      // Suppose this fn recieve a value "9"
-      // How this mask expects a value with floating numbers
-      // the "9" will be pushed after the separator
-      // and will become "0,09". So we just add ".00".
-      value = (/\./g).test(value) ? value : value + '.00';
     }
     var number = value.toString().replace(/[\D]/g, ""),
         clearDelimiter = new RegExp("^(0|\\"+ opts.delimiter +")"),


### PR DESCRIPTION
When `VMasker.toMoney` receives `19` (non-floated value) or a number that doesn't fullfil the estabilished precision, for instance `19.5` and precision set is 2, the number part and floated part get split wrongly. `19` will become `0,19` and `19.5` will become `1.95`. (You can try it out in bankfacil site, in console type `VMasker.toMoney(19)`.

Let me know if I need to do any changes before merging.
