### PR TITLE
fix vanilla-masker.js link

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 		<title>VanillaMasker</title>
-		<script src="/vanilla-masker.js"></script>
+		<script src="../lib/vanilla-masker.js"></script>
 		<link rel="stylesheet" type="text/css" href="styles.css">
 	</head>
 	<body>


### PR DESCRIPTION
The script link was pointing to a file that didn't exist
